### PR TITLE
Implement rescaling inputs for domain adaptation

### DIFF
--- a/exit
+++ b/exit
@@ -1,0 +1,626 @@
+[33m07e5431[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mmain[m[33m, [m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m)[m changes to domain_adaptation.py
+[33m606214c[m implement rescaling for get_unsupervised_loader and mean_teacher_adaptation
+[33mfdc6b46[m added new mito model and removed old mito models 2 and 3 - new model is called mitochondria2 (#156)
+[33m9a7a089[m[33m ([m[1;33mtag: [m[1;33m0.4.1[m[33m)[m Fix export of touching objects to IMOD (#155)
+[33m3459903[m[33m ([m[1;33mtag: [m[1;33m0.4.0[m[33m)[m Support checkpoint initialization for supervised training; fix issues… (#154)
+[33m8cb080c[m Fix supervised-training CLI and add test (#153)
+[33m21f9850[m Add prepocess to pred func (#149)
+[33me362fe0[m added mitov3 model - average voxel_size in nm: 2.87 (#147)
+[33m3c31509[m Change preprint link to publication link
+[33m8df45a1[m Merge pull request #141 from computational-cell-analytics/140-update-voxel-size-for-mitochondria2-model
+[33meffdb93[m Update inference.py
+[33m46b6300[m Update pool visualization
+[33m8d7ee71[m Merge pull request #139 from computational-cell-analytics/model-fixes
+[33mba1e5e7[m Fix mitochondria2 model and add proper model test
+[33m4dc4b21[m Update vesicle pool visualization
+[33mfc7ca4d[m Merge pull request #138 from computational-cell-analytics/convenience
+[33m3b0fad1[m Fix typo
+[33m6e3db6e[m Update size filter plugin to remove disconnected components
+[33m7046235[m Add cli to visualize vesicle pool assignments
+[33m457d558[m Save the pool color in the exported table
+[33md0f284a[m match z alignment to AZ seg
+[33mc028aa9[m Merge pull request #137 from computational-cell-analytics/2d_imod_export
+[33macc3908[m[33m ([m[1;31morigin/2d_imod_export[m[33m)[m z plane
+[33m71ec138[m testing
+[33m664f203[m Implement size filtering widget
+[33m58d54c9[m Merge branch 'main' of https://github.com/computational-cell-analytics/synapse-net into 2d_imod_export
+[33m10cbfd5[m Update segmentation_widget.py
+[33me8359ee[m Merge pull request #136 from computational-cell-analytics/minor-updates
+[33mee8a0ce[m Fix bug in new membrane post-processing
+[33mefb5851[m Update ribbon structure post-processing in segmentation GUI
+[33meb2d3ed[m Support setting multiple devices in segmentation
+[33md344d49[m 2D vesicle export to imod
+[33m9c252ed[m Implement scalable segmentation  (#134)
+[33m43eff47[m boundary mask for unsupervised training (#132)
+[33mbfccbf0[m wrong format extension
+[33me1996bd[m[33m ([m[1;33mtag: [m[1;33m0.3.0[m[33m)[m Merge pull request #133 from computational-cell-analytics/constantinpape-patch-2
+[33m0beffc8[m Update __version__.py
+[33m1e25907[m Merge pull request #131 from computational-cell-analytics/revision3
+[33m0ec2a50[m Update the voxel size for the new AZ model
+[33m75d60f9[m Update inference CLI so that it works with checkpoints
+[33mf76dbf7[m Add attempt at compartment evaluation code
+[33md8d7c1b[m Update AZ model
+[33m928f330[m Merge pull request #130 from computational-cell-analytics/revision2
+[33m1f3ad5f[m Update CLI training info and add community submission info to doc
+[33m480d714[m Update the SynapseNet trainign CLI
+[33mbe0917a[m Fix issues in training CLI and add domain adaptation CLI
+[33m70628f6[m Implement CLI for supervised training
+[33m0a8101e[m Update vesicle inference
+[33m408b807[m Merge pull request #121 from computational-cell-analytics/revision
+[33m7967b4c[m Update environment.yaml
+[33m8ea5b66[m more conservative SV filtering at z borders
+[33mfbe4a55[m minor az postprocessing for data analysis
+[33mf516ae4[m minor adjustment
+[33m34886d7[m fixed a few mistakes
+[33m6e95660[m make code more flexible
+[33m8763e49[m make usage of surface dice more general
+[33m0c30cf0[m updated SV seg h5
+[33m48618d0[m added compartment seg saved in h5
+[33mf17c349[m option to calc surface dice per component
+[33mad03103[m add dataset info
+[33md966ea3[m minor things for analysis; 1st implementation of surface dice for eval
+[33m7b83139[m change presynaptic filtering
+[33mcab9f2b[m Merge branch 'main' of https://github.com/computational-cell-analytics/synapse-net into revision
+[33me8788e5[m Delete analysis_results directory
+[33md6eaa66[m add boundary threshold for compartment seg
+[33m1ae7401[m Merge branch 'main' into revision
+[33mf465dbe[m Merge pull request #128 from computational-cell-analytics/comp_seg
+[33m78825be[m[33m ([m[1;31morigin/comp_seg[m[33m)[m add option to change boundary threshold for compartment seg
+[33mdb3e654[m small change for compartment segmentation
+[33ma9b714f[m minor addition
+[33mac4b9d7[m store segID, use existing seg
+[33m17b9368[m remove background from analysis
+[33mba09eca[m Update to_imod.py (#127)
+[33md7b9a1a[m exclude SV at boundary for automatic analysis
+[33m2fa3925[m Merge branch 'main' of https://github.com/computational-cell-analytics/synapse-net into revision
+[33m61bd683[m Update util.py (#126)
+[33m0785657[m fix import
+[33mb842bca[m new data analysis, not tested
+[33m6525651[m fix a few things
+[33mb1c8feb[m make training more usable
+[33m02da6a2[m Merge branch 'main' of https://github.com/computational-cell-analytics/synapse-net into revision
+[33m59c3534[m prepare for training AZ
+[33md2aa6d8[m empty crop without AZ annotation
+[33mb769a8e[m make az_thin more flexible
+[33mc41628c[m make prediction more flexible
+[33m5f66328[m cropping stem data
+[33mf8d801f[m Clean up AZ scripts and summarize current state
+[33md7f71a0[m Update AZ training data
+[33m39d69d5[m Implement AZ evaluation WIP
+[33m7dd6962[m Work on revision of AZ model WIP
+[33m2f4564e[m Update start_page.md (#123)
+[33mea5bbce[m Minor updates to documentation (#122)
+[33mf08ad89[m Add SBD to CryoVesNet evaluation
+[33md23d544[m Add code for tomogram on-the-fly processing (#117)
+[33m964d6c3[m Update environment.yaml (#120)
+[33m71a0343[m Add mask intersection post-processing (#115)
+[33mba00244[m Add more outputs to debug performance (#108)
+[33me2f4efa[m Update start_page.md
+[33m9e59086[m added cristae model (#113)
+[33m07a6b61[m[33m ([m[1;33mtag: [m[1;33m0.2.0[m[33m)[m Update __version__.py
+[33m5a18127[m Activate windows tests (#88)
+[33m20cc7b1[m Merge pull request #107 from computational-cell-analytics/more-models-and-samples
+[33m38b1a2c[m Additional models
+[33m237cde7[m Add new sample data
+[33m2afed55[m added cristae model and single channel transfrom (#100)
+[33m92be799[m Merge pull request #106 from computational-cell-analytics/adapt-mps-tiling
+[33m169ddd4[m changed tiling for mps
+[33m8cc71f1[m added foreground threshold to hmap (#101)
+[33m09aa4e0[m Optimize scaler (#99)
+[33m4741402[m added MPS default tiling (#104)
+[33mf7cca9a[m Portal things + few things for paper revision (#102)
+[33m38f7907[m Add support for cryo-et-data (#89)
+[33m1f0387a[m Merge pull request #98 from computational-cell-analytics/cooper
+[33maf10206[m use updated mito model
+[33m7dc2490[m Add missing enviroment file for gpu installation on windows
+[33mb62ac1a[m added params to configure in_channels for model creation (#97)
+[33m51e28a4[m Add new mito model (#96)
+[33m4245c5b[m Add boundary threshold to hmap (#95)
+[33m0483f53[m added boundary threshold and area threshold to mitochondrai segmentation (#94)
+[33m07b4e7e[m added seed_distance to parameters of mitochondria segmentation (#93)
+[33m9847f1b[m Fix documentation typo
+[33mb56906c[m Update environment file in build_docs
+[33m3d70179[m Merge pull request #92 from computational-cell-analytics/update-install
+[33mf57105c[m Update installation instructions
+[33m190a62f[m Fix typo in doc
+[33md829715[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into main
+[33mdee0935[m Add video links to README and documentation
+[33m5c080f7[m Save segmentations in analysis pipeline example
+[33m3ab9a8d[m Update documentation
+[33m79c6242[m Add napari plugin images for doc
+[33m9cb8763[m Implement segmentation post-processing widget
+[33mb75b968[m Add link to analysis script to documentation
+[33m9221c9e[m Minor typo fixes in the doc (#87)
+[33m1810805[m[33m ([m[1;33mtag: [m[1;33m0.1.0[m[33m)[m Merge pull request #79 from computational-cell-analytics/first-release
+[33m03d42a8[m Fix issues with inference code
+[33m9ceb256[m Merge branch 'main' into first-release
+[33m458ec90[m 78 improvements to vesicle pool assignment widget (#81)
+[33mc0afedb[m Update the cooper scripts
+[33mc75abd9[m Update the example scripts and add downloads for data from zenodo
+[33mba56b57[m Update tomo sample data and example analysis pipeline
+[33mfb1fcd0[m Fix issues in active zone segmentation
+[33ma7ff94e[m Udpate example analysis pipeline
+[33m22ea714[m Refactor segmentation functionality
+[33m8b5cf12[m Update example analysis pipeline and sample data
+[33m4b3b539[m Bump version; add outline for analysis pipeline
+[33m8a4d26d[m Update vesicle pool widget (#77)
+[33m9b94807[m Fix typo
+[33mb5c9986[m Add short headers for submodules
+[33m17557c9[m Install pdoc in doc workflow
+[33m7793579[m Add version to init
+[33m4415b18[m Try to fix doc build
+[33md0d307a[m Fix doc building
+[33m498eb5a[m Merge pull request #76 from computational-cell-analytics/clean-up
+[33mc4304c3[m Add short rdme to scripts
+[33mc81d2b0[m Rename library in all experiment scripts
+[33m004dca8[m Rename synaptic_reconstruction package to synapse_net
+[33mc4c7aaf[m Add missing scripts and gitignores
+[33mc8cc5ea[m Update documentation
+[33m064ff2d[m Fix issues in ribbon postprocessing
+[33m57b7258[m Merge pull request #75 from computational-cell-analytics/add-ribbon-inference
+[33m71f9b2c[m Add new sample data and test for file utils
+[33m1cc595e[m Add ribbon model and refactor IO functionality
+[33m0fe01c4[m Fix issues in doc
+[33mac90e63[m Update start_page.md
+[33m409bcb6[m Update README.md
+[33mefdee13[m Merge pull request #73 from computational-cell-analytics/68-create-a-widget-for-vesicle-pool-assignments
+[33m223baee[m Refactor plugin functionality, update pool widget
+[33mec1ff3e[m Merge branch 'main' into 68-create-a-widget-for-vesicle-pool-assignments
+[33mafeb8e7[m Merge pull request #74 from computational-cell-analytics/software-updates
+[33m333b24a[m Fix CI
+[33m9b3e7b5[m Add sample data, CI, and auto-scaling for segmenation CLI
+[33m90aa283[m chagned display name of vesicle morphology
+[33m6989b45[m added tooltip for query to see which filters can be applied
+[33m827ad03[m cleaned up code
+[33m414b4cb[m Update doc and envs
+[33mbc39941[m added vesicle pool widget
+[33mc4bbc00[m morphology in dedicated layer
+[33m8e8c25d[m fix right argument for sampling
+[33m77a10a9[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into main
+[33m8ef7559[m Fix type annotation
+[33m5f15a66[m Doc updates (#71)
+[33m1e2533f[m Update documentation and readme
+[33me6971f5[m fiexed morphology widgets
+[33md883a07[m Update all function doc strings
+[33me2565f6[m Merge branch 'main' into doc-updates
+[33ma65affb[m Update function doc strings
+[33mae2a472[m Merge pull request #70 from computational-cell-analytics/more-inner-ear-analysis
+[33m53e6c9b[m Add active zone inference
+[33m686a38a[m Merge branch 'main' into doc-updates
+[33md723d5c[m Merge pull request #52 from computational-cell-analytics/more-inner-ear-analysis
+[33m2cc8f92[m Merge branch 'main' into more-inner-ear-analysis
+[33m69d7a3d[m Remove lockfile
+[33mff11f88[m Add more evaluation scripts
+[33me4c3040[m Update docs WIP
+[33m1f392ef[m Add evaluation scripts for cooper data
+[33m2da1d37[m changed distance and morphology widgets to properly add data to segmetation layer's properties attribute
+[33m8dbe7d3[m Update build_docs.yaml
+[33md8e37f5[m Update build_docs.yaml
+[33m91e1237[m Update build_docs.yaml
+[33m76525c9[m Update build_docs.yaml
+[33m6b6d1b3[m Update build_docs.yaml
+[33me5b734c[m Update build_docs.yaml
+[33mb213c31[m Update build_docs.yaml
+[33me01b452[m Update build_docs.yaml
+[33m06ebbec[m Update build_docs.yaml
+[33m681fc5d[m Update build_docs.yaml
+[33mcf1d722[m Update build_docs.yaml
+[33mba25763[m Update build_docs.yaml
+[33m844b9b9[m Update build_docs.yaml
+[33m0dd3b18[m Update build_docs.yaml
+[33m37535b3[m Update build_docs.yaml
+[33m65d6dd3[m Update build_docs.yaml
+[33mbc53699[m Update build_docs.yaml
+[33mf62b8cf[m Update doc_env.yaml
+[33m3844f77[m Update doc_env.yaml
+[33m29f1768[m Update doc_env.yaml
+[33m65eac11[m Update doc_env.yaml
+[33m558fc4f[m Update doc_env.yaml
+[33mee89f73[m Update doc_env.yaml
+[33m1af04e3[m Update doc_env.yaml
+[33m64c8780[m Update build_docs.yaml
+[33me34d6b8[m Update build_docs.yaml
+[33mea885b2[m Update build_docs.yaml
+[33m3b27480[m Update doc_env.yaml
+[33ma57a742[m Update build_docs.yaml
+[33mb571218[m Update doc_env.yaml
+[33m7e4844d[m Update build_docs.yaml
+[33mc15173d[m Update build_docs.yaml
+[33mf9d7310[m Update build_docs.yaml
+[33md44aced[m Update build_docs.yaml
+[33me212583[m Merge pull request #69 from computational-cell-analytics/59-build-documentation
+[33mefe2219[m[33m ([m[1;31morigin/59-build-documentation[m[33m)[m added github workflow yaml etc
+[33md226a94[m Merge pull request #67 from computational-cell-analytics/58-add-widget-for-morphology-analysis
+[33m0bacc48[m refactored some code in to_imod.py
+[33m19d9217[m added files for doc
+[33m4ec71a9[m table data index and label_id mixup is corrected
+[33mbe5808e[m implemented changes mentioned in PR 67
+[33me0262f9[m Merge pull request #66 from computational-cell-analytics/65-add-mito-train-script
+[33mca9b803[m Merge branch 'main' into 58-add-widget-for-morphology-analysis
+[33ma59ed03[m removed oboslete code
+[33m063b3b6[m added morphology widget to measure morphology of structures in 2d and 3d volumetric data
+[33m70095c4[m Update util.py
+[33m3281438[m added default path for training data and removed obsolete code
+[33mb73b5be[m added train_mitochondria script and util for training
+[33mce94ea8[m Add CLI for IMOD export
+[33m3b4c6c4[m Update analyses
+[33m45ef1c3[m refactored  morphology widge
+[33mfe7dfae[m Update weights_only handling
+[33m9fd4017[m Add some TODOs for CLI update
+[33m4a33f11[m Simplify model type selection logic
+[33m2ec0fd5[m Add examples for network training (#61)
+[33m8df8eba[m some changed got lost
+[33m691f183[m added napari.yaml
+[33m9728951[m Update vesicle diameter analysis
+[33m59a38db[m Update all measurements for the inner ear analysis
+[33me0dfda6[m Merge branch 'main' into more-inner-ear-analysis
+[33me95dd45[m Merge pull request #60 from computational-cell-analytics/56-add-support-for-custom-model-paths-in-segmentation-plugin
+[33m3e11446[m Update weights_only handling
+[33m0db92fc[m Add some TODOs for CLI update
+[33mf3be90a[m Simplify model type selection logic
+[33m008860f[m Merge remote-tracking branch 'origin/main' into 56-add-support-for-custom-model-paths-in-segmentation-plugin
+[33ma974e65[m Add examples for network training (#61)
+[33m93a66c1[m Update data summary
+[33ma0c31a8[m Fix issue in data aggregation
+[33mcb693b1[m Update data summaries
+[33m51165a5[m Fix issues with the segmentation export to IMOD
+[33meb21abd[m added morphology and first approach to measure vesicles in UI
+[33m7941db0[m added custom model path with target selector to choose between desired segmentation functions
+[33m9b8c7a2[m Add more inner ear analysis code
+[33mc396113[m Merge pull request #55 from computational-cell-analytics/53-next-steps-plugin-implementation
+[33m5feff6a[m Update active zone analysis for SNAP/MUNC data
+[33m27c4d9d[m reworked mentioned parts
+[33mcf2898d[m Merge branch 'main' into 53-next-steps-plugin-implementation
+[33m6474587[m voxel size in UI and scale is automatically calculated if there is enough information
+[33m2ccf340[m Add script to extract vesicle diameters for inner ear data
+[33m3a13825[m added description to volume_reader
+[33m3569d4f[m chagned training resolution to dictionaries
+[33mdead9c4[m removed obsolete LOCs
+[33mcd54805[m added scale calculation based on resolution and voxel size
+[33md186ee8[m Add download urls and train resolutions for most models
+[33m19b2701[m Add functionality to extract training data info
+[33m5b778f7[m Fix issues in filter updates and add script for active zone segmentation
+[33m10854de[m Add sato as better default edge filter
+[33m79478c5[m added scale calculation based on resolution and voxel size
+[33me3d3798[m Add download urls and train resolutions for most models
+[33m186df5b[m Merge branch 'more-inner-ear-analysis' of https://github.com/computational-cell-analytics/synaptic-reconstruction into more-inner-ear-analysis
+[33m186c92d[m Update inner ear analysis scripts
+[33m0b7884d[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into more-inner-ear-analysis
+[33mef44f99[m Add functionality to extract training data info
+[33mbcc8863[m added dummy traiing_voxel_size and dynamic calculation of sclae
+[33m16512a7[m added voxel_size reading to reader plugin and stored it in napari.layer.metadata
+[33m903e59e[m Update inner ear analysis
+[33m30d4a08[m added new tiling logic and napari progress bar
+[33ma2758f4[m Fix issues in filter updates and add script for active zone segmentation
+[33m58f3e6b[m Add sato as better default edge filter
+[33m238b577[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction
+[33m305a80b[m Updates to inner ear training and eval
+[33m9472a47[m Merge pull request #51 from computational-cell-analytics/more-plugin-updates
+[33m4e19b6e[m Update mito segmentation
+[33mad4741b[m Update inner ear analysis
+[33ma051d85[m Update CLI and model logic
+[33m55074db[m Implement CLI WIP
+[33md991be3[m Update distance measurement widget
+[33mf74e5cd[m Update plugins WIP
+[33m0f40d3c[m Update inner ear analysis
+[33m38d6edf[m Merge pull request #50 from computational-cell-analytics/49-plugin-updates
+[33m9980c2b[m added distance to object to DistanceMeasureWidget feature and saving to csv file. _compute_seg_object_distances needed to be adapted to accept 2D data (prev. only 3D data was accepted)
+[33m514e1f1[m removed obsolete code
+[33m0ebd45c[m refactored layer_selector_widgets to BaseWidget and fixed loading image before plugin problem
+[33mff5be12[m Merge pull request #48 from computational-cell-analytics/plugin-updates
+[33md5faa99[m Updates to napari plugins and distance functionality
+[33m9581b2b[m Merge pull request #47 from computational-cell-analytics/45-user-interface
+[33m9622f88[m pooch loading with state_dict works.. layer_selector_widgets should be refactored to be in BaseWidget
+[33m36d834f[m Implement inner ear analysis WIP
+[33mf56436a[m Update structure segmentation training
+[33m7af1511[m added dynamic switch between segmentation functions absed on the model used
+[33mec1f050[m added segmentation widget
+[33m74c3e69[m Merge pull request #46 from computational-cell-analytics/update-comp-seg
+[33m59e01dd[m[33m ([m[1;31morigin/update-comp-seg[m[33m)[m Update result visualization
+[33m64d56e5[m Update segmentation functionality and add more inference scripts
+[33m993a006[m Merge branch 'update-comp-seg' of https://github.com/computational-cell-analytics/synaptic-reconstruction into update-comp-seg
+[33maad578c[m Update compartment model training
+[33m6daf9de[m Update compartment segmentation
+[33m54204cc[m Add annotation script
+[33mbc981e2[m Finalize CryoVesNet evaluation
+[33m6011472[m Update compartment segmentation code
+[33mc35b04d[m Update cryovesnet evaluation
+[33mc5fceb7[m Add prediction for compartments WIP
+[33m01804ec[m Update compartment segmentation logic
+[33mbbecced[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction
+[33m9aba9f3[m Implement cryo-ves-net evaluation for cooper data
+[33m7657af0[m Merge pull request #43 from computational-cell-analytics/inner-ear-eval
+[33mf75091d[m Update inner ear analysis
+[33m4cdd288[m More updates in the ribbon segmentation
+[33m85c5670[m Update postprocessing code
+[33m13f2272[m Update domain adaptation training logic for inner ear structures
+[33mbe05252[m Merge branch 'main' into inner-ear-eval
+[33m696f47d[m Update inner ear structure postprocessing
+[33m9cb25c2[m Merge pull request #42 from computational-cell-analytics/fix-da-training
+[33m309d3c1[m Merge pull request #39 from computational-cell-analytics/38-add-sampler-to-domain-adaptation
+[33m26e37eb[m Fix some issues in DA training
+[33m05d3555[m Update supervised_training.py
+[33m062b956[m Update for inner ear analysis
+[33mc61de04[m Update postprocessing script
+[33m3cd5f0c[m Implement IMOD mask export WIP
+[33meabd2aa[m Merge pull request #41 from computational-cell-analytics/sm-dev
+[33mb58f1d3[m fix mask error
+[33mfeadf6f[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into sm-dev
+[33mbe7ba41[m active zone training
+[33mfc7a3a1[m Update radius extraction for IMOD
+[33m475a9b5[m Merge pull request #40 from computational-cell-analytics/compartment-training
+[33m4363ce4[m Update cryovesnet prediction
+[33m1b777bf[m Update compartment segmentation
+[33mfebad29[m Work on compartment segmentation
+[33md47dc0a[m Implement compartment segmentation WIP
+[33m8a6026b[m Some updates to compartment training and cryo-ves-net
+[33m20a1390[m Merge branch 'main' into compartment-training
+[33me9c8cf9[m Implement training for compartment model
+[33m967304e[m addded sampler to domain adaptation
+[33md1b6bba[m Add readme for cryovesnet
+[33mcdf3315[m Add initial code for cryovesnet
+[33m997d804[m Update ground-truth annotation scripts
+[33mc590869[m Update processing scripts for compartment annotations
+[33m760cd7c[m more about 2D
+[33ma18a992[m Update correction table parsing for inner ear synapses
+[33md59f0ff[m Update sam preprocessing for compartment annotation
+[33mdee589f[m Update gt generation
+[33mc412b47[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into sm-dev
+[33m47428e5[m masked segmentation
+[33mdd2a9ae[m Update README.md
+[33m83a5cfa[m Implement factor to increase the vesicle radius in the IMOD export
+[33me6d189c[m Merge pull request #36 from computational-cell-analytics/vesicle-inference-updates
+[33m4696743[m Merge pull request #37 from computational-cell-analytics/sm-dev
+[33m3edbacf[m segmentation also for other data than h5
+[33m7b460b2[m Unify all segmentation functions
+[33mfbfe91b[m Update scaling and masking functionality in mito and vesicle segmentation
+[33m3baea1c[m Add support for prediction with mask WIP
+[33m05bd064[m Implement script for mask extraction from IMOD and mask interpolation
+[33md09c245[m Update border filtering
+[33m492a427[m extract presynapse
+[33m3a8f223[m DA for inner ear data, excluding testset data
+[33ma5c8965[m DA for endbulb data
+[33mf977967[m DA for cryo data
+[33m8ca79b3[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into sm-dev
+[33m89ae892[m Merge pull request #35 from computational-cell-analytics/update-distance-seg
+[33m11a668b[m Update vesicle segmentation
+[33m1bafacd[m fixing confusing print statement
+[33m63b9450[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into sm-dev
+[33m4c20a77[m Merge pull request #34 from computational-cell-analytics/ribbon-synapses
+[33m776e8e4[m small things
+[33m60d2692[m Update ribbon synapse evaluation
+[33m6802ad7[m Add code for ribbon synapse eval
+[33m8cf1806[m Merge pull request #33 from computational-cell-analytics/sm-dev
+[33ma2f351d[m correction of argparse
+[33m0cae179[m option to split dataset in only train and val
+[33m0d418dc[m Merge pull request #32 from computational-cell-analytics/structure-training
+[33m5ccf1a6[m[33m ([m[1;31morigin/structure-training[m[33m)[m Add domain adaptation script
+[33m149d8a1[m Merge pull request #31 from computational-cell-analytics/more-visualization
+[33md67fe84[m Merge branch 'main' into structure-training
+[33m9d02682[m minor additions
+[33m46cfb54[m Merge branch 'more-visualization' of https://github.com/computational-cell-analytics/synaptic-reconstruction into sm-dev
+[33md204845[m Minor update
+[33mdb812d1[m Finalize vesicle post-processing changes
+[33m9120dee[m Merge pull request #30 from computational-cell-analytics/sm-dev
+[33m7f1b058[m matching object imod export to vesicle export
+[33md324b28[m few more prints
+[33mb7b4a31[m Structure training updates
+[33mb52742b[m More updates WIP
+[33m796ec01[m Update post-processing WIP
+[33m79f0125[m Merge branch 'sm-dev' into more-visualization
+[33m482cddf[m Add new visualization script
+[33m5970812[m push everything once more
+[33m0c830b6[m can pass either model or model path for segmentation, functions have 2 options now, changed order of parameters
+[33m01b4cb1[m exclude files not directory
+[33mf10a2a4[m export vesicles for endbulb, not fully tested#
+[33m4fe8ef1[m fix 2D seg tiling size, implement 2D evaluation
+[33m4bf312a[m 2D vesicle segmentation
+[33mf965616[m evaluation script
+[33m85effc1[m assisting file, finalising h5 segmentation
+[33m208ba17[m fix tiling-halo issue; assisting files
+[33md30537c[m Update segmentation functionality
+[33m8afad01[m Merge pull request #29 from computational-cell-analytics/gt-extraction
+[33m9db47ed[m Finalize GT extraction for moser data
+[33m51166e7[m Add inner ear vesicle extraction script
+[33m9841fdf[m Implement IMOD structure export
+[33m47945f4[m Add script to check exported data
+[33m76654fb[m export AZ, endbulb, cristae, mito for wichmann data
+[33m196f5a2[m add small things for training
+[33m7dec298[m Add ground-truth export and analysis scripts for moser data
+[33m4e46957[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into sm-dev
+[33m87edf43[m finish training
+[33m80be9ba[m Update vesicle extraction for cryo data
+[33mb7f3f8b[m Update README.md
+[33mb50b829[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into sm-dev
+[33m8f7085e[m Fix issues with loss masking code
+[33m82ee06b[m don't redo already postprocessed, small addition
+[33mde5b644[m don't redo already postprocessed
+[33m305f81a[m Start code for cryo vesicle extraction
+[33m414677b[m Update default ignore table
+[33mf78c203[m Merge pull request #24 from computational-cell-analytics/actin
+[33m6332bb5[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into actin
+[33m3d42280[m Merge pull request #26 from computational-cell-analytics/masked-loss
+[33m7ea303a[m Merge branch 'main' into masked-loss
+[33m20f5180[m Merge pull request #22 from computational-cell-analytics/sm-dev
+[33mb582701[m Add actin visualization scripts
+[33m56217b0[m Add domain adaptation script for actin
+[33mf84f281[m improve vesicle postprocessing
+[33m2d8db55[m update right linux code for imod exportation
+[33mab2ca1d[m Implement masked loss
+[33mc796077[m Add more IMOD parsing functionality
+[33mb21a5ad[m Update frog synapse extraction
+[33mc297ed6[m Update analysis for manual annotations in inner ear synapses
+[33m4ee4ca0[m Use new column to parse inner ear synapses
+[33m54fb030[m postprocess shape with new functions
+[33mceda07f[m merging main and sm-dev
+[33m6c2669c[m Merge pull request #25 from computational-cell-analytics/shape-refinement
+[33m92cedcc[m[33m ([m[1;31morigin/shape-refinement[m[33m)[m Update manual vesicle analysis
+[33mc693336[m Minor fix
+[33mfc88c45[m Fix issues in vesicle refinement
+[33ma058aef[m Implement vesicle shape refinement
+[33m488ccb7[m trying out different wadershed functions
+[33m7096869[m passing ndim to RawDataset
+[33m61242bd[m first implementation of postprocessing vesicle shape seg
+[33me162f75[m Implement first version of actin prediction
+[33m653b9c2[m Merge branch 'main' into actin
+[33ma971a52[m Merge pull request #23 from computational-cell-analytics/cooper-vesicle-extraction
+[33ma73c796[m Implement vesicle correction for inner ear synapses
+[33m2def8e0[m 2D semisupervised, unsupervised, not fully tested
+[33mb7670ee[m add chages for 2D
+[33mf0a165a[m Add script for checking extracted vesicle ground-truth
+[33m799defc[m Implement actin segmentation training
+[33m468fa2e[m Finish vesicle extraction
+[33mad62a9a[m Add first version of vesicle extraction for cooper data
+[33mf6021b0[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into sm-dev
+[33m0a5d93d[m check for 2D
+[33m5a283ec[m Work on vesicle extraction WIP
+[33mf89fcd5[m Improvements in inner ear vesicle analysis
+[33mad68bd3[m Update validation table handling
+[33m411850f[m Merge pull request #20 from computational-cell-analytics/training
+[33m3d8cb77[m Implement training functionality
+[33m4832ea3[m Implement training WIP
+[33me101e0d[m Update vesicle GT processing
+[33mdd9ad05[m Implement vesicle postprocessing
+[33m06d3307[m Add scripts for ground-truth generation in cooper data
+[33ma0b8ee1[m Merge pull request #19 from computational-cell-analytics/non-ax-aligned-bb
+[33m8ff548f[m Add ground-truth extraction code
+[33m04663e4[m Enable import without napari-regiontable
+[33mda1a8a7[m Update correction pool logic
+[33mc3362dd[m Update inner ear analysis to take into account pool correction
+[33m08d6852[m Add new layer for vesicle pool correction
+[33m6233db5[m Merge pull request #18 from computational-cell-analytics/tile-and-border
+[33m7d369d6[m Make default tiling a function of VRAM and implement border clearing for vesicles
+[33m77d9ce6[m Fix bug for prediction with nested input folders
+[33m6e83143[m Enable different extensions for vesicle segmentation and update readme
+[33m21eaa65[m Merge pull request #16 from computational-cell-analytics/inference_updates
+[33m8485053[m Add documentation for the new inference code
+[33mc37babb[m Prepare data transfer documentation WIP
+[33m99c9abb[m Unify prediction scripts
+[33m4dd165f[m Update inference code in stucture segmentation script
+[33madba18e[m Update default tiling logic
+[33m409997e[m Update visualization script
+[33m5bcbb1d[m Merge pull request #15 from computational-cell-analytics/14-add-visualization-script-to-check-segmentations
+[33m840cb08[m added script that visualizes segmentation
+[33m5cfb164[m Merge pull request #13 from computational-cell-analytics/imod-export
+[33m2317fff[m Enable passing serialized torch models to prediction scripts
+[33m3162438[m Merge pull request #12 from computational-cell-analytics/inference-refactor
+[33m89da79e[m changed axis argument for standardize from list to tuple
+[33m0102ae8[m added cristae segmentation script and fixed incorrect usage of np.stack in inference/util.py
+[33m2fce111[m Implement imod vesicle export
+[33m95550f4[m Fix issue in inference_helper and add vesicle segmentation
+[33mb87d759[m Implement inference helper function
+[33mb21f24e[m Start refactoring inference functionality
+[33ma0dd0cf[m Merge pull request #10 from computational-cell-analytics/9-add-script-to-run-mitochondria-segmentation
+[33m5ddb555[m[33m ([m[1;31morigin/9-add-script-to-run-mitochondria-segmentation[m[33m)[m added compression to .tif export and slightly increased the min size filter for mitochondria
+[33m868fb99[m removed unnecessary code
+[33mcd58951[m added script to run mitochondria segmentation from directory or single path
+[33m0a17e75[m Merge pull request #8 from computational-cell-analytics/7-add-segmentation-functionality-for-cristae
+[33madd56fb[m removed file and removed file path from .gitignore
+[33m72ac866[m added cristae segmentation and simplified script
+[33m6c5ae24[m added docstring to semgent_cristae
+[33m31d8a1e[m refactored predict_with_torch_em
+[33m63abf2d[m changed from instance segmentation to semantic segmentation
+[33m5097cfd[m added test file to gitignore
+[33m8ecbf67[m added crstae segmentation
+[33m1c8a777[m Merge pull request #6 from computational-cell-analytics/4-add-segmentation-functionality-for-mitochondria-cristae
+[33m1efa6a7[m removed unnecessary imports
+[33mdfa5210[m added util file to reuse torch_em predict function and tidied up code
+[33m3af2613[m Stop tracking test.py
+[33m16856b0[m added mito inference script as well as type annotations for it and for vesicles
+[33mcc401d8[m added some more postprocessing steps
+[33m3e38632[m added mito inference script and generic post processing
+[33mb39d6ba[m Misc updates
+[33mf7de8d4[m Update binning
+[33m4a620a9[m New skip column
+[33m60e4426[m Fix issue in vesicle pool analysis
+[33mdbf9009[m Update vesicle extraction
+[33m2c23a04[m Update morphology computation
+[33m7e0c411[m Fix issue in analysis code
+[33mc210002[m Update morphology computation
+[33m777977b[m Update selected postprocessing
+[33m94c6a62[m Implement selected postprocessing WIP
+[33mb7cdae2[m Update validation table handling
+[33m58e5836[m Update tomogram rescaling and IMOD file processing
+[33m4910da3[m Update tomogram rescaling script
+[33ma6a5ad0[m Add script for tomogram rescaling WIP
+[33m389be29[m Add data extraction scripts for FrogEM
+[33m77af8f8[m Update README.md
+[33m2f4ee2e[m Update README.md
+[33mc7afefb[m Update README.md
+[33m412970d[m Update README.md
+[33m0808f11[m Update vesicle annotation
+[33m355692c[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into main
+[33m014809e[m Update manual segmentation handling for inner synapses
+[33mda6a470[m Add vesicle annotation tool
+[33m4805cd7[m Fix naming errors in manual analysis
+[33m681b48f[m Simplify manual processing
+[33m1ed1823[m Update manual segmentation processing
+[33mf435f67[m Update inner ear scripts
+[33m4f2c4c3[m Update result checking
+[33m75c2128[m Minor fixes in run analysis
+[33m1407896[m Update analysis code
+[33me1134c1[m Add checking for manual analysis
+[33m835836f[m Treat corrected vesicle pools in run analysis
+[33m092a94d[m More robust analysis code
+[33m6fa7b60[m Updates to morphology processing
+[33m5e54294[m Add export for imod point annotations
+[33m7eba5fe[m Implement analysis of manual annotations WIP
+[33me577cc9[m Add script to check the correction table
+[33mce5beb4[m Update binning in inner ear result correction
+[33m6ed64e4[m Fix color assignment without results
+[33mde44c5c[m Update vesicle correction script
+[33m6b13ea5[m Minor updates to analysis scripts
+[33mc3635d5[m Fix typo in inner ear processing script
+[33maac4ef4[m Update data processing scripts for inner ear tomogram
+[33mfd0aa81[m Updates for correction inclusion
+[33m6ee2333[m Handle tomograms with two ribbons in inner ear analysis
+[33m454bfda[m Update distance based post-processing
+[33m675b525[m Update processing scripts
+[33m5be3930[m Update structure post-processing for segmentation v2
+[33m077846d[m Update processing scripts for inner ear synapses
+[33mc4bc452[m Implement new training data export for inner ear synaptic structures
+[33m685a4bb[m Implement hole closing
+[33md0afa16[m Fix distance line creation for empty distances
+[33m2533f4c[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into main
+[33macdb13b[m Add script for segmentation validation
+[33mf862d6b[m Catch issue in mesh volume computation
+[33m1d1bbe7[m Minor updates
+[33mbcaa48f[m Update morphology analysis
+[33m68c7240[m Update result visualization for inner ear
+[33m6b8bb88[m Implement analysis
+[33md523872[m Update structure post-processing
+[33mc9907d0[m Update structure postprocessing
+[33m6aeb3d9[m Update segmentation
+[33md8b87c4[m Implement processing for new microscope
+[33m69627cf[m Fix ribbon post-processing
+[33mf7c1e97[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction
+[33m3e232b4[m Update processing code
+[33mcc58a20[m Update visualization scripts
+[33mcd76ab9[m Update post-processing for ribbon and membrane
+[33m81e6a15[m Add post-processing for structure segmentation
+[33medffed3[m Update segmentation functionality
+[33mfe78084[m Add imod extraction functionality and script
+[33me4cb154[m Implement table parsing for inner ear experiments
+[33me32f0f3[m Update scripts for inner ear processing
+[33meb3ba29[m Update gitignore
+[33md48445d[m Update scripts for inner ear processing
+[33m2d780d5[m Fix bug in distance measurements
+[33m0ed51da[m Add simple script to check segmentations
+[33meed7bab[m Add morphology computation for ribbon synapses
+[33md5cf40e[m Fix issues in distance visualization for ribbon synapses
+[33mbf12559[m Fix issue in distance sorting
+[33m599b427[m Enable not filtering duplicates in distance measurement
+[33m725abed[m Fix issue in nearest neighbor filtering logic
+[33mcbc06ad[m[33m ([m[1;31morigin/tools-for-vesicles[m[33m)[m Update liposome measurement script
+[33m80f7d43[m Fix bug in distance computation
+[33m6a4d90d[m Add script for distance measurement in liposomes
+[33m2d45062[m Add vesicle pool assignment for inner ear vesicles
+[33m5c0def7[m Merge branch 'main' of https://github.com/computational-cell-analytics/synaptic-reconstruction into tools-for-vesicles
+[33m6fb683c[m Enable precomputing distances
+[33m64af817[m Add preliminary boundary segmentations
+[33m42f740e[m Add more functionality for ribbon syn segmentation and distance measurements
+[33mbf10d4c[m Merge pull request #1 from computational-cell-analytics/tools-for-vesicles
+[33m937577d[m Update distance measurement tool
+[33m8f864f1[m Implement functionality for filtering ribbons
+[33maa97e08[m Implement napari-based tools for segmentation correction and displaying distances
+[33m09075e5[m Initial commit

--- a/synapse_net/training/domain_adaptation.py
+++ b/synapse_net/training/domain_adaptation.py
@@ -245,7 +245,7 @@ def mean_teacher_adaptation(
             On-the-fly rescaling is currently only implemented for unsupervised training. 
             `unsupervised_train_paths` and `unsupervised_val_paths` must be mrc files to read input voxel size 
             and determine scale factor.
-        device: GPU ID for training. 
+        device: GPU device for training. 
         check: Whether to check the training and validation loaders instead of running training.
     """ # noqa
     assert (supervised_train_paths is None) == (supervised_val_paths is None)
@@ -328,7 +328,7 @@ def mean_teacher_adaptation(
     loss = self_training.DefaultSelfTrainingLoss()
     loss_and_metric = self_training.DefaultSelfTrainingLossAndMetric()
 
-    device = torch.device(f"cuda:{device}") if torch.cuda.is_available() else torch.device("cpu")
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
     trainer = trainer_class(
         name=name,
         model=model,

--- a/synapse_net/training/domain_adaptation.py
+++ b/synapse_net/training/domain_adaptation.py
@@ -8,6 +8,7 @@ import mrcfile
 import torch
 import torch_em
 import torch_em.self_training as self_training
+from torch_em.self_training.logger import SelfTrainingTensorboardLogger
 from elf.io import open_file
 from sklearn.model_selection import train_test_split
 
@@ -18,7 +19,152 @@ from .supervised_training import (
 from ..inference.inference import get_model_path, compute_scale_from_voxel_size, get_available_models
 from ..inference.util import _Scaler
 
+#TODO add background_mask functionality to torch_em `MeanTeacherTrainer` and `DefaultPseudoLabeler`
+class PseudoLabelerWithBackgroundMask(self_training.DefaultPseudoLabeler):
+    """Subclass of DefaultPseudoLabeler, which can subtract background from the pseudo labels if a background mask is provided.
+        By default, assumes that the first channel contains the transformed raw data and the second channel contains the background mask.
 
+    Args:
+        confidence_mask_channel: A specific channel to use for computing the confidence mask.
+            By default the confidence mask is computed across all channels independently.
+            This is useful, if only one of the channels encodes a probability.
+        raw_channel: Channel index of the raw data, which will be used as input to the teacher model
+        background_mask_channel: Channel index of the background mask, which will be subtracted from the pseudo labels.
+        kwargs: Additional keyword arguments for `self_training.DefaultPseudoLabeler`.
+    """
+    def __init__(
+        self,
+        confidence_mask_channel: Optional[int] = None,
+        raw_channel: Optional[int] = 0,
+        background_mask_channel: Optional[int] = 1,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.confidence_mask_channel = confidence_mask_channel
+        self.raw_channel = raw_channel
+        self.background_mask_channel = background_mask_channel
+        
+    def _subtract_background(self, pseudo_labels: torch.Tensor, background_mask: torch.Tensor):
+        bool_mask = background_mask.bool()
+        return pseudo_labels.masked_fill(bool_mask, 0)
+
+    def __call__(self, teacher: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        """Compute pseudo-labels.
+
+        Args:
+            teacher: The teacher model.
+            input_: The input for this batch.
+
+        Returns:
+            The pseudo-labels.
+        """
+        if input_.ndim != 5:
+            raise ValueError(f"Expect data with 5 dimensions (B, C, D, H, W), got shape {input_.shape}.")
+        
+        has_background_mask = input_.shape[1] > 1 
+
+        if has_background_mask:
+            if self.background_mask_channel > input_.shape[1]:
+                raise ValueError(f"Channel index {self.background_mask_channel} is out of bounds for shape {input_.shape}.")
+
+            background_mask = input_[:, self.background_mask_channel].unsqueeze(1)
+            input_ = input_[:, self.raw_channel].unsqueeze(1)
+
+        pseudo_labels = teacher(input_)
+
+        if self.activation is not None:
+            pseudo_labels = self.activation(pseudo_labels)
+        if self.confidence_threshold is None:
+            label_mask = None
+        else:
+            mask_input = pseudo_labels if self.confidence_mask_channel is None\
+                else pseudo_labels[self.confidence_mask_channel:(self.confidence_mask_channel+1)]
+            label_mask = self._compute_label_mask_both_sides(mask_input) if self.threshold_from_both_sides\
+                else self._compute_label_mask_one_side(mask_input)
+            if self.confidence_mask_channel is not None:
+                size = (pseudo_labels.shape[0], pseudo_labels.shape[1], *([-1] * (pseudo_labels.ndim - 2)))
+                label_mask = label_mask.expand(*size)
+        
+        if has_background_mask:
+            pseudo_labels = self._subtract_background(pseudo_labels, background_mask)
+
+        return pseudo_labels, label_mask
+
+class MeanTeacherTrainerWithBackgroundMask(self_training.MeanTeacherTrainer):
+    """Subclass of MeanTeacherTrainer, updated to handle cases where the background mask is provided. 
+    Once the pseudo labels are computed, the second channel of the teacher input is dropped, if it exists.
+    The second channel of the student input is also dropped, if it exists, since it is not needed for training.
+
+    Args:
+        kwargs: Additional keyword arguments for `self_training.MeanTeacherTrainer`.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _train_epoch_unsupervised(self, progress, forward_context, backprop):
+        self.model.train()
+
+        n_iter = 0
+        t_per_iter = time.time()
+
+        # Sample from both the supervised and unsupervised loader.
+        for xu1, xu2 in self.unsupervised_train_loader:
+            
+            # Keep only the first channel for xu2 (student input).
+            if xu2.ndim != 5:
+                raise ValueError(f"Expect xu2 to have 5 dimensions (B, C, D, H, W), got shape {xu2.shape}.")
+            if xu2.shape[1] > 1:
+                xu2 = xu2[:, :1].contiguous()
+
+            xu1, xu2 = xu1.to(self.device, non_blocking=True), xu2.to(self.device, non_blocking=True)
+
+            teacher_input, model_input = xu1, xu2
+            
+            with forward_context(), torch.no_grad():
+                # Compute the pseudo labels.
+                pseudo_labels, label_filter = self.pseudo_labeler(self.teacher, teacher_input)
+
+            # Drop the second channel for xu1 (teacher input) after computing the pseudo labels.
+            if xu1.ndim != 5:
+                raise ValueError(f"Expect xu1 to have 5 dimensions (B, C, D, H, W), got shape {xu1.shape}.")
+            if xu1.shape[1] > 1:
+                xu1 = xu1[:, :1].contiguous()
+
+            # If we have a sampler then check if the current batch matches the condition for inclusion in training.
+            if self.sampler is not None:
+                keep_batch = self.sampler(pseudo_labels, label_filter)
+                if not keep_batch:
+                    continue
+
+            self.optimizer.zero_grad()
+            # Perform unsupervised training
+            with forward_context():
+                loss = self.unsupervised_loss(self.model, model_input, pseudo_labels, label_filter)
+            backprop(loss)
+
+            if self.logger is not None:
+                with torch.no_grad(), forward_context():
+                    pred = self.model(model_input) if self._iteration % self.log_image_interval == 0 else None
+                self.logger.log_train_unsupervised(
+                    self._iteration, loss, xu1, xu2, pred, pseudo_labels, label_filter
+                )
+                lr = [pm["lr"] for pm in self.optimizer.param_groups][0]
+                self.logger.log_lr(self._iteration, lr)
+                if self.pseudo_labeler.confidence_threshold is not None:
+                    self.logger.log_ct(self._iteration, self.pseudo_labeler.confidence_threshold)
+
+            with torch.no_grad():
+                self._momentum_update()
+
+            self._iteration += 1
+            n_iter += 1
+            if self._iteration >= self.max_iteration:
+                break
+            progress.update(1)
+
+        t_per_iter = (time.time() - t_per_iter) / n_iter
+        return t_per_iter
+    
 def mean_teacher_adaptation(
     name: str,
     unsupervised_train_paths: Tuple[str],
@@ -37,14 +183,16 @@ def mean_teacher_adaptation(
     n_iterations: int = int(1e4),
     n_samples_train: Optional[int] = None,
     n_samples_val: Optional[int] = None,
-    train_mask_paths: Optional[Tuple[str]] = None,
-    val_mask_paths: Optional[Tuple[str]] = None,
+    train_sample_mask_paths: Optional[Tuple[str]] = None,
+    val_sample_mask_paths: Optional[Tuple[str]] = None,
+    train_background_mask_paths: Optional[Tuple[str]] = None,
     patch_sampler: Optional[callable] = None,
     pseudo_label_sampler: Optional[callable] = None,
-    device: int = 0,
+    target_vsize: Optional[float] = None,
+    device: Optional[torch.device] = None,
     check: bool = False,
 ) -> None:
-    """Run domain adaptation to transfer a network trained on a source domain for a supervised
+    """Run domain adapation to transfer a network trained on a source domain for a supervised
     segmentation task to perform this task on a different target domain.
 
     We support different domain adaptation settings:
@@ -55,11 +203,9 @@ def mean_teacher_adaptation(
 
     Args:
         name: The name for the checkpoint to be trained.
-        unsupervsied_train_paths: Filepaths to the hdf5 files or similar file formats
-            for the training data in the target domain.
+        unsupervsied_train_paths: Filepaths to the hdf5 or mrc files for the training data in the target domain.
             This training data is used for unsupervised learning, so it does not require labels.
-        unsupervised_val_paths: Filepaths to the hdf5 files or similar file formats
-            for the validation data in the target domain.
+        unsupervised_val_paths: Filepaths to the hdf5 or mrc files for the validation data in the target domain.
             This validation data is used for unsupervised learning, so it does not require labels.
         patch_shape: The patch shape used for a training example.
             In order to run 2d training pass a patch shape with a singleton in the z-axis,
@@ -87,13 +233,21 @@ def mean_teacher_adaptation(
             based on the patch_shape and size of the volumes used for training.
         n_samples_val: The number of val samples per epoch. By default this will be estimated
             based on the patch_shape and size of the volumes used for validation.
-        train_mask_paths: Sample masks used by the patch sampler to accept or reject patches for training.
-        val_mask_paths: Sample masks used by the patch sampler to accept or reject patches for validation.
-        patch_sampler: Accept or reject patches based on a condition.
-        pseudo_label_sampler: Mask out regions of the pseudo labels where the teacher is not confident before updating the gradients.
-        device: GPU ID for training.
+        train_sample_mask_paths: Filepaths to the sample masks used by the patch sampler to accept or reject 
+            patches for training.
+        val_sample_mask_paths: Filepaths to the sample masks mrc files used by the patch sampler to accept or reject 
+            patches for validation. 
+        train_background_mask_paths: Filepaths to the background masks mrc files used for training.
+            Background masks are used to subtract background from the pseudo labels before the forward pass. 
+        patch_sampler: A sampler for rejecting patches based on a defined conditon. 
+        pseudo_label_sampler: A sampler for rejecting pseudo-labels based on a defined condition.
+        target_vsize: Target voxel size in Angstrom for rescaling inputs. 
+            On-the-fly rescaling is currently only implemented for unsupervised training. 
+            `unsupervised_train_paths` and `unsupervised_val_paths` must be mrc files to read input voxel size 
+            and determine scale factor.
+        device: GPU ID for training. 
         check: Whether to check the training and validation loaders instead of running training.
-    """  # noqa
+    """ # noqa
     assert (supervised_train_paths is None) == (supervised_val_paths is None)
     is_2d, _ = _determine_ndim(patch_shape)
 
@@ -115,31 +269,41 @@ def mean_teacher_adaptation(
             model = torch.load(source_checkpoint, weights_only=False)
         reinit_teacher = False
 
-    optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.5, patience=5)
 
     # self training functionality
-    pseudo_labeler = self_training.DefaultPseudoLabeler(confidence_threshold=confidence_threshold)
+    if train_background_mask_paths is not None:
+        pseudo_labeler = PseudoLabelerWithBackgroundMask(confidence_threshold=confidence_threshold, background_mask_channel=1)
+        trainer_class = MeanTeacherTrainerWithBackgroundMask
+    else:
+        pseudo_labeler = self_training.DefaultPseudoLabeler(confidence_threshold=confidence_threshold)
+        trainer_class = self_training.MeanTeacherTrainer
+
     loss = self_training.DefaultSelfTrainingLoss()
     loss_and_metric = self_training.DefaultSelfTrainingLossAndMetric()
-
+   
     unsupervised_train_loader = get_unsupervised_loader(
-        data_paths=unsupervised_train_paths,
-        raw_key=raw_key,
-        patch_shape=patch_shape,
-        batch_size=batch_size,
-        n_samples=n_samples_train,
-        sample_mask_paths=train_mask_paths,
-        sampler=patch_sampler
+        data_paths=unsupervised_train_paths, 
+        raw_key=raw_key, 
+        patch_shape=patch_shape, 
+        batch_size=batch_size, 
+        n_samples=n_samples_train, 
+        sample_mask_paths=train_sample_mask_paths, 
+        background_mask_paths=train_background_mask_paths,
+        sampler=patch_sampler,
+        target_vsize=target_vsize,
     )
     unsupervised_val_loader = get_unsupervised_loader(
-        data_paths=unsupervised_val_paths,
-        raw_key=raw_key,
-        patch_shape=patch_shape,
-        batch_size=batch_size,
-        n_samples=n_samples_val,
-        sample_mask_paths=val_mask_paths,
-        sampler=patch_sampler
+        data_paths=unsupervised_val_paths, 
+        raw_key=raw_key, 
+        patch_shape=patch_shape, 
+        batch_size=batch_size, 
+        n_samples=n_samples_val, 
+        sample_mask_paths=val_sample_mask_paths, 
+        background_mask_paths=None,
+        sampler=patch_sampler,
+        target_vsize=target_vsize,
     )
 
     if supervised_train_paths is not None:

--- a/synapse_net/training/semisupervised_training.py
+++ b/synapse_net/training/semisupervised_training.py
@@ -6,11 +6,12 @@ import h5py
 import torch
 import torch_em
 import torch_em.self_training as self_training
+import torch_em.transform
 from torchvision import transforms
 
 from synapse_net.file_utils import read_mrc
 from .supervised_training import get_2d_model, get_3d_model, get_supervised_loader, _determine_ndim
-
+from pathlib import Path
 
 def weak_augmentations(p: float = 0.75) -> callable:
     """The weak augmentations used in the unsupervised data loader.
@@ -31,10 +32,44 @@ def weak_augmentations(p: float = 0.75) -> callable:
     ])
     return torch_em.transform.raw.get_raw_transform(normalizer=norm, augmentation1=aug)
 
-def drop_mask_channel(x):
-    x = x[:1]
-    return x
+#TODO add new arguments for channel-wise transforms to torch_em to minimize the need for helper functions
+
+# Helper functions:
+#   DropChannel - drops the unneeded sample_mask channel after sampling patches
+#   ComposedTransform - combine transforms
+#   ChannelWiseRawTransform - applies raw_transform to only the raw channel (channel 0)
+#   ChannelWiseAugmentations - applies augmentations to only the raw channel
+#   ChannelSplitterSampler - torch_em `MinForegroundSampler` expects raw and mask to be passed as x and y, 
+#       but in `get_unsupervised_loader` they are stacked
+
+class DropChannel:
+    def __init__(self, channel: int):
+        self.channel = channel
+
+    def __call__(self, data):
+        if data.ndim != 4:
+            raise ValueError("Expect data with 4 dimensions (C, D, H, W).")
     
+        if self.channel >= data.shape[0]:
+            raise ValueError(f"Drop channel index {self.channel} is out of bounds for shape {data.shape}.")
+        return np.delete(data, self.channel, axis=0)
+
+class ChannelWiseRawTransform:
+    def __init__(self, base_transform: callable, transform_channel: int = 0):
+        self.base_transform = base_transform
+        self.transform_channel = transform_channel
+
+    def __call__(self, data):
+        if data.ndim != 4:
+            raise ValueError("Expect data with 4 dimensions (C, D, H, W).")
+
+        if self.transform_channel >= data.shape[0]:
+            raise ValueError(f"Transform channel index {self.transform_channel} is out of bounds for shape {data.shape}.")
+            
+        output = data.copy()
+        output[self.transform_channel] = self.base_transform(data[self.transform_channel])
+        return output
+
 class ComposedTransform:
     def __init__(self, *funcs):
         self.funcs = funcs
@@ -44,6 +79,23 @@ class ComposedTransform:
             x = f(x)
         return x
 
+class ChannelWiseAugmentations:
+    def __init__(self, transform_channel: int = 0, base_augmentations: Optional[callable] = None):
+        self.transform_channel = transform_channel
+        
+        self.base_augmentations = weak_augmentations() if base_augmentations is None else base_augmentations
+
+    def __call__(self, data):
+        if data.ndim != 4:
+            raise ValueError("Expect data with 4 dimensions (C, D, H, W).") 
+
+        if self.transform_channel >= data.shape[0]:
+            raise ValueError(f"Augmentations channel index {self.transform_channel} is out of bounds for shape {data.shape}.")   
+
+        output = data.clone() 
+        output[self.transform_channel] = self.base_augmentations(data[self.transform_channel])
+        return output
+
 class ChannelSplitterSampler: 
     def __init__(self, sampler):
         self.sampler = sampler
@@ -51,21 +103,38 @@ class ChannelSplitterSampler:
     def __call__(self, x):
         raw, mask = x[0], x[1]
         return self.sampler(raw, mask)
+    
+def get_stacked_path(inputs: List[np.ndarray]):
+    """Helper function to get_unsupervised_loader(). In cases where a mask input is given, creates a temporary 
+     h5 file containing the stacked inputs (raw, sample_mask, background mask) to be used to RawDataset().
 
+    Args:
+        inputs: List of numpy arrays to be stacked along axis 0.
+
+    Returns: Path to temporary h5 file containing stacked inputs.
+    """
+    stacked = np.stack(inputs, axis=0)
+    tmp_path = f"/tmp/stacked_{uuid.uuid4().hex}.h5"
+    with h5py.File(tmp_path, "w") as f:
+        f.create_dataset("raw", data=stacked, compression="gzip")
+    return tmp_path
+    
 def get_unsupervised_loader(
     data_paths: Tuple[str],
     raw_key: str,
     patch_shape: Tuple[int, int, int],
     batch_size: int,
-    n_samples: Optional[int],
+    n_samples: Optional[int] = None,
     sample_mask_paths: Optional[Tuple[str]] = None,
+    background_mask_paths: Tuple[str] = None,
     sampler: Optional[callable] = None,
     exclude_top_and_bottom: bool = False, 
+    target_vsize: Optional[float] = None,
 ) -> torch.utils.data.DataLoader:
     """Get a dataloader for unsupervised segmentation training.
 
     Args:
-        data_paths: The filepaths to the hdf5 files containing the training data.
+        data_paths: The filepaths to the hdf5 or mrc files containing the training data.
         raw_key: The key that holds the raw data inside of the hdf5.
         patch_shape: The patch shape used for a training example.
             In order to run 2d training pass a patch shape with a singleton in the z-axis,
@@ -75,45 +144,161 @@ def get_unsupervised_loader(
             based on the patch_shape and size of the volumes used for training.
         exclude_top_and_bottom: Whether to exluce the five top and bottom slices to
             avoid artifacts at the border of tomograms.
-        sample_mask_paths: The filepaths to the corresponding sample masks for each tomogram.
+        sample_mask_paths: The mrc filepaths to the corresponding sample masks for each tomogram.
+        background_mask_paths: The mrc filepaths to the corresponding background masks for each tomogram.
         sampler: Accept or reject patches based on a condition.
+        target_vsize: Target voxel size in Angstrom for rescaling. 
+            Source voxel size is read from mrc `data_paths` to determine the scale factor.
 
     Returns:
         The PyTorch dataloader.
     """
     # We exclude the top and bottom slices where the tomogram reconstruction is bad.
-    # TODO this seems unneccesary if we have a boundary mask - remove? 
     if exclude_top_and_bottom:
         roi = np.s_[5:-5, :, :]
     else:
         roi = None
-    # stack tomograms and masks and write to temp files to use as input to RawDataset()    
-    if sample_mask_paths is not None:
-        assert len(data_paths) == len(sample_mask_paths), \
-            f"Expected equal number of data_paths and and sample_masks_paths, got {len(data_paths)} data paths and {len(sample_mask_paths)} mask paths."
-        
-        stacked_paths = []
-        for i, (data_path, mask_path) in enumerate(zip(data_paths, sample_mask_paths)):
-            raw = read_mrc(data_path)[0]
-            mask = read_mrc(mask_path)[0]
-            stacked = np.stack([raw, mask], axis=0)
 
-            tmp_path = f"/tmp/stacked{i}_{uuid.uuid4().hex}.h5"
-            with h5py.File(tmp_path, "w") as f:
-                f.create_dataset("raw", data=stacked, compression="gzip")
-            stacked_paths.append(tmp_path)
+    # get configurations
+    has_sample_mask = sample_mask_paths is not None
+    has_background_mask = background_mask_paths is not None
+    apply_rescale = target_vsize is not None
+
+    # initialize class instances
+    base_transform = torch_em.transform.get_raw_transform()
+    channelwise_raw_transform = ChannelWiseRawTransform(base_transform)
+    drop_channel = DropChannel(channel = 1)
+
+    if apply_rescale:
+        
+        # read voxel size from mrc to determine the rescale factor
+        mrc_path = next((p for p in data_paths if Path(p).suffix == ".mrc"), None)
+
+        if mrc_path is None:
+            raise ValueError("No mrc file found in data_paths to read voxel size.")
+        
+        source_vsize = read_mrc(mrc_path)[1]
+
+        scale = (
+            source_vsize["z"] / (target_vsize / 10),
+            source_vsize["y"] / (target_vsize / 10),
+            source_vsize["x"] / (target_vsize / 10),
+        )
+        # rescaling is performed differently for float and int data
+        rescale_raw = torch_em.transform.generic.Rescale(scale)                
+        rescale_mask = torch_em.transform.generic.Rescale(scale, is_label=True)
+        
+    # stack tomograms and masks and write to temp files to use as input to RawDataset()    
+    stacked_paths = []
+
+    # Case 1: both sample masks and background masks are provided, e.g., for the train data loader
+    if has_sample_mask and has_background_mask: 
+        assert len(data_paths) == len(sample_mask_paths) == len(background_mask_paths), \
+        f"Expected equal number of paths, got {len(data_paths)} data paths, {len(sample_mask_paths)} sample mask paths \
+            and {len(background_mask_paths)} background mask paths."
+    
+        for i, (data_path, sample_mask_path, background_mask_path) in enumerate(zip(data_paths, sample_mask_paths, background_mask_paths)):
+            if Path(data_path).suffix == ".h5":
+                with h5py.File(data_path, "r") as f:
+                    raw = f[raw_key][:]
+            else:
+                raw = read_mrc(data_path)[0]
+            sample_mask = read_mrc(sample_mask_path)[0]
+            background_mask = read_mrc(background_mask_path)[0]
+
+            # rescaling is performed differently for to float and int data 
+            if apply_rescale:
+                raw = rescale_raw(raw)
+                sample_mask = rescale_mask(sample_mask)
+                background_mask = rescale_mask(background_mask)
+
+            stacked_path = get_stacked_path([raw, sample_mask, background_mask])
+            stacked_paths.append(stacked_path)
 
         # update variables for RawDataset()
         data_paths = tuple(stacked_paths)    
-        base_transform = torch_em.transform.get_raw_transform()
-        raw_transform = ComposedTransform(base_transform, drop_mask_channel)
+        raw_transform = ComposedTransform(channelwise_raw_transform, drop_channel)
+        augmentations = (ChannelWiseAugmentations(), ChannelWiseAugmentations())
         sampler = ChannelSplitterSampler(sampler)
         with_channels = True 
-    else:
-        raw_transform = torch_em.transform.get_raw_transform()
-        with_channels = False
-        sampler = None
 
+    # Case 2: only sample masks are provided, e.g., for the validation data loader
+    elif has_sample_mask:
+        assert len(data_paths) == len(sample_mask_paths), \
+        f"Expected equal number of paths, got {len(data_paths)} data paths and {len(sample_mask_paths)} sample mask paths."
+
+        for i, (data_path, sample_mask_path) in enumerate(zip(data_paths, sample_mask_paths)):
+            if Path(data_path).suffix == ".h5":
+                with h5py.File(data_path, "r") as f:
+                    raw = f[raw_key][:]
+            else:
+                raw = read_mrc(data_path)[0]
+            sample_mask = read_mrc(sample_mask_path)[0]
+
+            if apply_rescale:
+                raw = rescale_raw(raw)
+                sample_mask = rescale_mask(sample_mask)
+            
+            stacked_path = get_stacked_path([raw, sample_mask])
+            stacked_paths.append(stacked_path)
+
+        # update variables for RawDataset()
+        data_paths = tuple(stacked_paths)    
+        raw_transform = ComposedTransform(channelwise_raw_transform, drop_channel)
+        augmentations = (weak_augmentations(), weak_augmentations())
+        sampler = ChannelSplitterSampler(sampler)
+        with_channels = True 
+
+    # Case 3: only background masks are provided 
+    elif has_background_mask:
+        assert len(data_paths) == len(background_mask_paths), \
+        f"Expected equal number of paths, got {len(data_paths)} data paths and {len(background_mask_paths)} background mask paths."
+
+        for i, (data_path, background_mask_path) in enumerate(zip(data_paths, background_mask_paths)):
+            if Path(data_path).suffix == ".h5":
+                with h5py.File(data_path, "r") as f:
+                    raw = f[raw_key][:]
+            else:
+                raw = read_mrc(data_path)[0]
+            background_mask = read_mrc(background_mask_path)[0]
+            
+            if apply_rescale:
+                raw = rescale_raw(raw)
+                background_mask = rescale_mask(background_mask)
+
+            stacked_path = get_stacked_path([raw, background_mask])
+            stacked_paths.append(stacked_path)
+
+        # update variables for RawDataset()
+        data_paths = tuple(stacked_paths)    
+        raw_transform = base_transform
+        augmentations = (ChannelWiseAugmentations(), ChannelWiseAugmentations())
+        sampler = None
+        with_channels = True 
+
+    # Case 4: neither mask is present, use default behavior
+    else:
+        for i, data_path in enumerate(data_paths):
+            if Path(data_path).suffix == ".h5":
+                with h5py.File(data_path, "r") as f:
+                    raw = f[raw_key][:]
+            else:
+                raw = read_mrc(data_path)[0]
+
+            if apply_rescale:
+                raw = rescale_raw(raw)
+
+            stacked_path = get_stacked_path([raw])
+            stacked_paths.append(stacked_path)
+        
+        # update variables for RawDataset()
+        data_paths = tuple(stacked_paths) 
+        raw_transform = base_transform
+        augmentations = (weak_augmentations(), weak_augmentations())
+        sampler = None
+        with_channels = False
+    
+    raw_key = "raw"
     _, ndim = _determine_ndim(patch_shape)
     transform = torch_em.transform.get_augmentations(ndim=ndim)
 
@@ -121,8 +306,6 @@ def get_unsupervised_loader(
         n_samples_per_ds = None
     else:
         n_samples_per_ds = int(n_samples / len(data_paths))
-
-    augmentations = (weak_augmentations(), weak_augmentations())
 
     datasets = [
         torch_em.data.RawDataset(path, raw_key, patch_shape, raw_transform, transform, roi=roi,
@@ -135,7 +318,6 @@ def get_unsupervised_loader(
     loader = torch_em.segmentation.get_data_loader(ds, batch_size=batch_size,
                                                    num_workers=num_workers, shuffle=True)
     return loader
-
 
 # TODO: use different paths for supervised and unsupervised training
 # (We are currently not using this functionality directly, so this is not a high priority)

--- a/synapse_net/training/semisupervised_training.py
+++ b/synapse_net/training/semisupervised_training.py
@@ -169,6 +169,7 @@ def get_unsupervised_loader(
     Returns:
         The PyTorch dataloader.
     """
+    
     # We exclude the top and bottom slices where the tomogram reconstruction is bad.
     if exclude_top_and_bottom:
         roi = np.s_[5:-5, :, :]
@@ -236,7 +237,6 @@ def get_unsupervised_loader(
         raw_transform = ComposedTransform(channelwise_raw_transform, drop_channel)
         augmentations = (ChannelWiseAugmentations(), ChannelWiseAugmentations())
         sampler = ChannelSplitterSampler(sampler)
-        with_channels = True 
 
     # Case 2: only sample masks are provided, e.g., for the validation data loader
     elif has_sample_mask:
@@ -266,7 +266,6 @@ def get_unsupervised_loader(
         raw_transform = ComposedTransform(channelwise_raw_transform, drop_channel)
         augmentations = (weak_augmentations(), weak_augmentations())
         sampler = ChannelSplitterSampler(sampler)
-        with_channels = True 
 
     # Case 3: only background masks are provided 
     elif has_background_mask:
@@ -294,11 +293,11 @@ def get_unsupervised_loader(
         raw_transform = base_transform
         augmentations = (ChannelWiseAugmentations(), ChannelWiseAugmentations())
         sampler = None
-        with_channels = True 
 
     # Case 4: neither mask is present, use default behavior
     else:
         for i, data_path in enumerate(data_paths):
+            
             if Path(data_path).suffix == ".h5":
                 with h5py.File(data_path, "r") as f:
                     raw = f[raw_key][:]
@@ -308,7 +307,7 @@ def get_unsupervised_loader(
             if apply_rescale:
                 raw = rescale_raw(raw)
                 print(f"{Path(data_path).stem}: rescaled inputs to {target_vsize}A with shape {raw.shape}")
-
+ 
             stacked_path = get_stacked_path([raw])
             stacked_paths.append(stacked_path)
         
@@ -317,11 +316,11 @@ def get_unsupervised_loader(
         raw_transform = base_transform
         augmentations = (weak_augmentations(), weak_augmentations())
         sampler = None
-        with_channels = False
     
     raw_key = "raw"
     _, ndim = _determine_ndim(patch_shape)
     transform = torch_em.transform.get_augmentations(ndim=ndim)
+    with_channels = True
 
     if n_samples is None:
         n_samples_per_ds = None
@@ -334,6 +333,7 @@ def get_unsupervised_loader(
         for path in data_paths
     ]
     ds = torch.utils.data.ConcatDataset(datasets)
+
     num_workers = 4 * batch_size 
     loader = torch_em.segmentation.get_data_loader(ds, batch_size=batch_size,
                                                    num_workers=num_workers, shuffle=True)

--- a/synapse_net/training/supervised_training.py
+++ b/synapse_net/training/supervised_training.py
@@ -6,6 +6,7 @@ import torch
 import torch_em
 from sklearn.model_selection import train_test_split
 from torch_em.model import AnisotropicUNet, UNet2d
+from torch_em.transform.raw import get_raw_transform, normalize_percentile
 
 from synapse_net.inference.inference import get_model_path, get_available_models
 
@@ -101,6 +102,7 @@ def get_supervised_loader(
     ignore_label: Optional[int] = None,
     label_transform: Optional[callable] = None,
     label_paths: Optional[Tuple[str]] = None,
+    percentile_norm: bool = False,
     **loader_kwargs,
 ) -> torch.utils.data.DataLoader:
     """Get a dataloader for supervised segmentation training.
@@ -168,11 +170,13 @@ def get_supervised_loader(
     elif len(label_paths) != len(data_paths):
         raise ValueError(f"Data paths and label paths don't match: {len(data_paths)} != {len(label_paths)}")
 
+    raw_transform = get_raw_transform(normalizer=normalize_percentile) if percentile_norm else None
     loader = torch_em.default_segmentation_loader(
         data_paths, raw_key,
         label_paths, label_key, sampler=sampler,
         batch_size=batch_size, patch_shape=patch_shape, ndim=ndim,
         is_seg_dataset=True, label_transform=label_transform, transform=transform,
+        raw_transform=raw_transform,
         num_workers=num_workers, shuffle=shuffle, n_samples=n_samples,
         label_dtype=label_dtype, rois=rois, **loader_kwargs,
     )
@@ -205,6 +209,8 @@ def supervised_training(
     out_channels: int = 2,
     mask_channel: bool = False,
     checkpoint_path: Optional[str] = None,
+    save_every_kth_epoch: Optional[int] = None,
+    percentile_norm: bool = False,
     **loader_kwargs,
 ):
     """Run supervised segmentation training.
@@ -249,16 +255,20 @@ def supervised_training(
         mask_channel: Whether the last channels in the labels should be used for masking the loss.
             This can be used to implement more complex masking operations and is not compatible with `ignore_label`.
         checkpoint_path: Path to the directory where 'best.pt' resides; continue training this model.
+        save_every_kth_epoch: Save checkpoints after every kth epoch in a separate file.
+            The corresponding checkpoints will be saved with the naming scheme 'epoch-{epoch}.pt'.
         loader_kwargs: Additional keyword arguments for the dataloader.
     """
     train_loader = get_supervised_loader(train_paths, raw_key, label_key, patch_shape, batch_size,
                                          n_samples=n_samples_train, rois=train_rois, sampler=sampler,
                                          ignore_label=ignore_label, label_transform=label_transform,
-                                         label_paths=train_label_paths, **loader_kwargs)
+                                         label_paths=train_label_paths, percentile_norm=percentile_norm,
+                                         **loader_kwargs)
     val_loader = get_supervised_loader(val_paths, raw_key, label_key, patch_shape, batch_size,
                                        n_samples=n_samples_val, rois=val_rois, sampler=sampler,
                                        ignore_label=ignore_label, label_transform=label_transform,
-                                       label_paths=val_label_paths, **loader_kwargs)
+                                       label_paths=val_label_paths, percentile_norm=percentile_norm,
+                                       **loader_kwargs)
 
     if check:
         from torch_em.util.debug import check_loader
@@ -317,7 +327,7 @@ def supervised_training(
         loss=loss,
         metric=metric,
     )
-    trainer.fit(n_iterations)
+    trainer.fit(n_iterations, save_every_kth_epoch=save_every_kth_epoch)
 
 
 def _derive_key_from_files(files, key):


### PR DESCRIPTION
motivation
- a source model was trained on data with vsize 10A, so the adapted model should also be trained on 10A data. 

two ideas to solve this problem:
1. rescaling after patch extraction
2. rescale full volume inputs then write to temp files

I decided to try option 2. because option 1. requires rescaling then resizing to get back to the original patch size. We are already writing to temp files so I thought rescaling could be done at this step, because just rescaling (one interpolation) would probably result in less information lost than rescale + resize (two interpolations). 

changes to semisupervised_training.py `get_unsupervised_loader`
- rescaling inputs to `target_vsize`, applied differently to float data and int data (mask)
- rescaling factor is automatically calculated by reading the voxel size from an .mrc file
- rescaled volumes are written to temporary files, which are given to `RawDataset()`
- rewrite `get_stacked_paths()` to be more memory efficient, write to $TMPDIR instead of /tmp
- tested case 2 (raw + sample mask) - works
- tested case 4 (raw only) - works

changes to domain_adaptation.py `mean_teacher_adaptation`
- add `target_vsize` argument
- moved data loaders and `check_loader`, to before `torch_em.load_model`
- before it was loading the model from the checkpoint which would spawn a bunch of workers resulting in freezing; this can be avoided when checking the loader