### PR TITLE
added elf wrapper to cristae segment function 

### DIFF
--- a/synapse_net/inference/cristae.py
+++ b/synapse_net/inference/cristae.py
@@ -124,7 +124,6 @@ def segment_cristae(
         The segmentation mask as a numpy array, or a tuple containing the segmentation mask
         and the predictions if return_predictions is True.
     """
-    verbose = True
     mitochondria = kwargs.pop("extra_segmentation", None)
     if mitochondria is None:
         # try extract from input volume

--- a/synapse_net/inference/cristae.py
+++ b/synapse_net/inference/cristae.py
@@ -8,6 +8,7 @@ from elf.wrapper.base import (
     MultiTransformationWrapper,
 )
 from skimage.morphology import binary_erosion, ball
+from skimage.measure import regionprops
 import numpy as np
 import torch
 
@@ -22,21 +23,41 @@ def _run_segmentation(
     erode_voxels=3,
 ):
     if mito_seg is not None:
-        # apply 3D erosion with a halo
+
+        # 1. Eagerly process instance erosion using global regionprops
         if erode_voxels > 0:
-            halo_size = (erode_voxels, erode_voxels, erode_voxels)
+            if verbose:
+                t_erode = time.time()
+                print("Eroding small mitochondria instances globally...")
+
+            # Load into memory to get accurate global bounding boxes and sizes.
+            # this can cause issue with limited memory (RAM)
+            mito_data = mito_seg[:] if hasattr(mito_seg, '__getitem__') else mito_seg
+            eroded_mito_data = np.zeros_like(mito_data)
+
             footprint = ball(erode_voxels)
+            props = regionprops(mito_data)
 
-            def erode_block(block):
-                return binary_erosion(block != 0, footprint=footprint)
+            for prop in props:
+                sl = prop.slice
+                # Isolate this specific instance within its bounding box
+                instance_mask = (mito_data[sl] == prop.label)
 
-            mito_seg = SimpleTransformationWrapperWithHalo(
-                mito_seg,
-                transformation=erode_block,
-                halo=halo_size
-            )
+                # Apply erosion
+                instance_mask = binary_erosion(instance_mask, footprint=footprint)
 
-        # mask the foreground using MultiTransformationWrapper
+                # Write the (potentially eroded) mask back to the output array
+                eroded_mito_data[sl][instance_mask] = prop.label
+
+            # Replace our working variable with the newly processed array
+            mito_seg = eroded_mito_data
+
+            if verbose:
+                print(f"Instance erosion completed in {time.time() - t_erode:.2f} s")
+
+        # 2. Mask the foreground lazily
+        # Even though mito_seg is now in memory, foreground might not be.
+        # MultiTransformationWrapper safely handles this mix.
         def mask_foreground(inputs):
             fg_block, mito_block = inputs
             return np.where(mito_block != 0, fg_block, 0)
@@ -48,8 +69,7 @@ def _run_segmentation(
             apply_to_list=True
         )
 
-    # apply the threshold
-
+    # 3. Apply the threshold lazily
     def threshold_block(block):
         return block > 0.5
 
@@ -58,20 +78,22 @@ def _run_segmentation(
         transformation=threshold_block
     )
 
-    # get the segmentation via seeded watershed
+    # 4. Get the segmentation via seeded watershed
     t0 = time.time()
     seg = parallel.label(binary_foreground, block_shape=block_shape, verbose=verbose)
     if verbose:
         print("Compute connected components in", time.time() - t0, "s")
 
-    # size filter
+    # 5. Size filter
     t0 = time.time()
     ids, sizes = parallel.unique(seg, return_counts=True, block_shape=block_shape, verbose=verbose)
     filter_ids = ids[sizes < min_size]
     seg[np.isin(seg, filter_ids)] = 0
     if verbose:
         print("Size filter in", time.time() - t0, "s")
+
     seg = np.where(seg > 0, 1, 0)
+
     return seg
 
 

--- a/synapse_net/inference/cristae.py
+++ b/synapse_net/inference/cristae.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Tuple, Union
 import elf.parallel as parallel
 from elf.wrapper.base import (
     SimpleTransformationWrapper,
-    SimpleTransformationWrapperWithHalo,
     MultiTransformationWrapper,
 )
 from skimage.morphology import binary_erosion, ball

--- a/synapse_net/inference/cristae.py
+++ b/synapse_net/inference/cristae.py
@@ -24,11 +24,11 @@ def _run_segmentation(
 ):
     if mito_seg is not None:
 
-        # 1. Eagerly process instance erosion using global regionprops
+        # Process instance erosion using global regionprops
         if erode_voxels > 0:
             if verbose:
                 t_erode = time.time()
-                print("Eroding small mitochondria instances globally...")
+                print("Eroding mitochondria instances globally...")
 
             # Load into memory to get accurate global bounding boxes and sizes.
             # this can cause issue with limited memory (RAM)
@@ -55,7 +55,7 @@ def _run_segmentation(
             if verbose:
                 print(f"Instance erosion completed in {time.time() - t_erode:.2f} s")
 
-        # 2. Mask the foreground lazily
+        #  Mask the foreground lazily
         # Even though mito_seg is now in memory, foreground might not be.
         # MultiTransformationWrapper safely handles this mix.
         def mask_foreground(inputs):
@@ -69,7 +69,7 @@ def _run_segmentation(
             apply_to_list=True
         )
 
-    # 3. Apply the threshold lazily
+    # Apply the threshold lazily
     def threshold_block(block):
         return block > 0.5
 
@@ -78,13 +78,13 @@ def _run_segmentation(
         transformation=threshold_block
     )
 
-    # 4. Get the segmentation via seeded watershed
+    # Get the segmentation via seeded watershed
     t0 = time.time()
     seg = parallel.label(binary_foreground, block_shape=block_shape, verbose=verbose)
     if verbose:
         print("Compute connected components in", time.time() - t0, "s")
 
-    # 5. Size filter
+    # Size filter
     t0 = time.time()
     ids, sizes = parallel.unique(seg, return_counts=True, block_shape=block_shape, verbose=verbose)
     filter_ids = ids[sizes < min_size]

--- a/synapse_net/inference/cristae.py
+++ b/synapse_net/inference/cristae.py
@@ -2,6 +2,12 @@ import time
 from typing import Dict, List, Optional, Tuple, Union
 
 import elf.parallel as parallel
+from elf.wrapper.base import (
+    SimpleTransformationWrapper,
+    SimpleTransformationWrapperWithHalo,
+    MultiTransformationWrapper,
+)
+from skimage.morphology import binary_erosion, ball
 import numpy as np
 import torch
 
@@ -12,11 +18,49 @@ def _run_segmentation(
     foreground, verbose, min_size,
     # blocking shapes for parallel computation
     block_shape=(128, 256, 256),
+    mito_seg=None,
+    erode_voxels=3,
 ):
+    if mito_seg is not None:
+        # apply 3D erosion with a halo
+        if erode_voxels > 0:
+            halo_size = (erode_voxels, erode_voxels, erode_voxels)
+            footprint = ball(erode_voxels)
+
+            def erode_block(block):
+                return binary_erosion(block != 0, footprint=footprint)
+
+            mito_seg = SimpleTransformationWrapperWithHalo(
+                mito_seg,
+                transformation=erode_block,
+                halo=halo_size
+            )
+
+        # mask the foreground using MultiTransformationWrapper
+        def mask_foreground(inputs):
+            fg_block, mito_block = inputs
+            return np.where(mito_block != 0, fg_block, 0)
+
+        foreground = MultiTransformationWrapper(
+            mask_foreground,
+            foreground,
+            mito_seg,
+            apply_to_list=True
+        )
+
+    # apply the threshold
+
+    def threshold_block(block):
+        return block > 0.5
+
+    binary_foreground = SimpleTransformationWrapper(
+        foreground,
+        transformation=threshold_block
+    )
 
     # get the segmentation via seeded watershed
     t0 = time.time()
-    seg = parallel.label(foreground > 0.5, block_shape=block_shape, verbose=verbose)
+    seg = parallel.label(binary_foreground, block_shape=block_shape, verbose=verbose)
     if verbose:
         print("Compute connected components in", time.time() - t0, "s")
 
@@ -89,7 +133,7 @@ def segment_cristae(
         tiling=tiling, with_channels=with_channels, channels_to_standardize=channels_to_standardize, verbose=verbose
     )
     foreground, boundaries = pred[:2]
-    seg = _run_segmentation(foreground, verbose=verbose, min_size=min_size)
+    seg = _run_segmentation(foreground, verbose=verbose, min_size=min_size, mito_seg=mito_seg)
     seg = scaler.rescale_output(seg, is_segmentation=True)
 
     if return_predictions:

--- a/synapse_net/inference/cristae.py
+++ b/synapse_net/inference/cristae.py
@@ -14,6 +14,36 @@ import torch
 from synapse_net.inference.util import get_prediction, _Scaler
 
 
+def _erode_instances(mito_data, erode_voxels, verbose):
+    """Erodes instances globally and returns a memory-efficient boolean mask."""
+    if verbose:
+        t_erode = time.time()
+        print("Eroding mitochondria instances globally...")
+
+    footprint = ball(erode_voxels)
+    props = regionprops(mito_data)
+
+    # Allocate a boolean array
+    eroded_binary_mask = np.zeros(mito_data.shape, dtype=bool)
+
+    for prop in props:
+        sl = prop.slice
+
+        # Isolate this specific instance within its bounding box
+        instance_mask = (mito_data[sl] == prop.label)
+
+        # Apply erosion
+        eroded_mask = binary_erosion(instance_mask, footprint=footprint)
+
+        # Write True to the newly eroded locations in our boolean array
+        eroded_binary_mask[sl][eroded_mask] = True
+
+    if verbose:
+        print(f"Instance erosion completed in {time.time() - t_erode:.2f} s")
+
+    return eroded_binary_mask
+
+
 def _run_segmentation(
     foreground, verbose, min_size,
     # blocking shapes for parallel computation
@@ -21,52 +51,21 @@ def _run_segmentation(
     mito_seg=None,
     erode_voxels=3,
 ):
-    if mito_seg is not None:
+    mito_seg = _erode_instances(mito_seg, erode_voxels, verbose)
 
-        # Process instance erosion using global regionprops
-        if erode_voxels > 0:
-            if verbose:
-                t_erode = time.time()
-                print("Eroding mitochondria instances globally...")
+    # Mask the foreground lazily
+    # Even though mito_seg is now in memory, foreground might not be.
+    # MultiTransformationWrapper safely handles this mix.
+    def mask_foreground(inputs):
+        fg_block, mito_block = inputs
+        return np.where(mito_block != 0, fg_block, 0)
 
-            # Load into memory to get accurate global bounding boxes and sizes.
-            # this can cause issue with limited memory (RAM)
-            mito_data = mito_seg[:] if hasattr(mito_seg, '__getitem__') else mito_seg
-            eroded_mito_data = np.zeros_like(mito_data)
-
-            footprint = ball(erode_voxels)
-            props = regionprops(mito_data)
-
-            for prop in props:
-                sl = prop.slice
-                # Isolate this specific instance within its bounding box
-                instance_mask = (mito_data[sl] == prop.label)
-
-                # Apply erosion
-                instance_mask = binary_erosion(instance_mask, footprint=footprint)
-
-                # Write the (potentially eroded) mask back to the output array
-                eroded_mito_data[sl][instance_mask] = prop.label
-
-            # Replace our working variable with the newly processed array
-            mito_seg = eroded_mito_data
-
-            if verbose:
-                print(f"Instance erosion completed in {time.time() - t_erode:.2f} s")
-
-        #  Mask the foreground lazily
-        # Even though mito_seg is now in memory, foreground might not be.
-        # MultiTransformationWrapper safely handles this mix.
-        def mask_foreground(inputs):
-            fg_block, mito_block = inputs
-            return np.where(mito_block != 0, fg_block, 0)
-
-        foreground = MultiTransformationWrapper(
-            mask_foreground,
-            foreground,
-            mito_seg,
-            apply_to_list=True
-        )
+    foreground = MultiTransformationWrapper(
+        mask_foreground,
+        foreground,
+        mito_seg,
+        apply_to_list=True
+    )
 
     # Apply the threshold lazily
     def threshold_block(block):
@@ -77,19 +76,17 @@ def _run_segmentation(
         transformation=threshold_block
     )
 
-    # Get the segmentation via seeded watershed
     t0 = time.time()
     seg = parallel.label(binary_foreground, block_shape=block_shape, verbose=verbose)
     if verbose:
         print("Compute connected components in", time.time() - t0, "s")
 
     # Size filter
-    t0 = time.time()
-    ids, sizes = parallel.unique(seg, return_counts=True, block_shape=block_shape, verbose=verbose)
-    filter_ids = ids[sizes < min_size]
-    seg[np.isin(seg, filter_ids)] = 0
-    if verbose:
-        print("Size filter in", time.time() - t0, "s")
+    if min_size > 0:
+        t0 = time.time()
+        parallel.size_filter(seg, out=seg, min_size=min_size, block_shape=block_shape, verbose=verbose)
+        if verbose:
+            print("Size filter in", time.time() - t0, "s")
 
     seg = np.where(seg > 0, 1, 0)
 
@@ -127,6 +124,7 @@ def segment_cristae(
         The segmentation mask as a numpy array, or a tuple containing the segmentation mask
         and the predictions if return_predictions is True.
     """
+    verbose = True
     mitochondria = kwargs.pop("extra_segmentation", None)
     if mitochondria is None:
         # try extract from input volume


### PR DESCRIPTION
and also masked the foreground prediction. Added binary erosion to mito_seg to avoid detecting cristae between mitochondria.

This resolves following issues:
- cristae segmentation outside of mitochondria
- cristae segmentation in between adjacent mitochondria
- out-of-memory crashes for big volumes